### PR TITLE
Add supports for `readOnly` field

### DIFF
--- a/lib/EditorJs.tsx
+++ b/lib/EditorJs.tsx
@@ -10,7 +10,6 @@ export interface EditorJsProps {
 
   onChange?: (api: API, data?: OutputData) => void
   onReady?: (instance?: EditorJS) => void,
-  onToggleReadOnly?: (readOnly?: boolean) => void,
   onCompareBlocks?: (
     newBlocks: BlockToolData | undefined,
     oldBlocks: BlockToolData | undefined
@@ -37,8 +36,6 @@ class EditorJsContainer extends React.PureComponent<Props> {
       this.instance?.readOnly.toggle(readOnly)
       // @ts-ignore
       this.instance!.configuration!.readOnly = readOnly
-
-      this.handleToggleReadOnly(readOnly)
     }
 
     if (!enableReInitialize || !data) {
@@ -75,15 +72,6 @@ class EditorJsContainer extends React.PureComponent<Props> {
     }
 
     onReady(this.instance)
-  }
-
-  handleToggleReadOnly = (readOnly?: boolean) => {
-    const { onToggleReadOnly } = this.props
-    if (!onToggleReadOnly) {
-      return
-    }
-
-    onToggleReadOnly(readOnly)
   }
 
   initEditor() {

--- a/lib/EditorJs.tsx
+++ b/lib/EditorJs.tsx
@@ -10,6 +10,7 @@ export interface EditorJsProps {
 
   onChange?: (api: API, data?: OutputData) => void
   onReady?: (instance?: EditorJS) => void,
+  onToggleReadOnly?: (readOnly?: boolean) => void,
   onCompareBlocks?: (
     newBlocks: BlockToolData | undefined,
     oldBlocks: BlockToolData | undefined
@@ -34,6 +35,10 @@ class EditorJsContainer extends React.PureComponent<Props> {
     if (prevReadOnly !== readOnly) {
       // Toggle readOnly mode
       this.instance?.readOnly.toggle(readOnly)
+      // @ts-ignore
+      this.instance!.configuration!.readOnly = readOnly
+
+      this.handleToggleReadOnly(readOnly)
     }
 
     if (!enableReInitialize || !data) {
@@ -48,8 +53,8 @@ class EditorJsContainer extends React.PureComponent<Props> {
   }
 
   handleChange = async (api: API) => {
-    const { onCompareBlocks, onChange, data } = this.props
-    if (!onChange) {
+    const { onCompareBlocks, onChange, data, readOnly } = this.props
+    if (!onChange || readOnly) {
       return
     }
 
@@ -70,6 +75,15 @@ class EditorJsContainer extends React.PureComponent<Props> {
     }
 
     onReady(this.instance)
+  }
+
+  handleToggleReadOnly = (readOnly?: boolean) => {
+    const { onToggleReadOnly } = this.props
+    if (!onToggleReadOnly) {
+      return
+    }
+
+    onToggleReadOnly(readOnly)
   }
 
   initEditor() {
@@ -112,7 +126,7 @@ class EditorJsContainer extends React.PureComponent<Props> {
   }
 
   destroyEditor() {
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
       if (!this.instance) {
         resolve()
         return


### PR DESCRIPTION
1. The main part of changes in this commit, is the section where we must ignore the `save` callback on **handleChange** function when the editor-instance is `readOnly`. the editor maybe gets changed dynamically from **editable** to **read-only**, and when it happens, the handleChange function maybe gets triggered and the *save* function is called. that's when an Error occurs from EditorJS module. that is no good. we don't want that!

2. The `readOnly` field of **configuration** object is being toggled after toggling the global `readOnly` variable of the EditorJsContainer class. this part is sometimes vital for some purposes on other projects, because of poor implementation of read-only property in the main EditorJS module.

3. Added a new function: `onToggleReadOnly`. it triggers when the `readOnly` is being toggled by the EditorJS instance. this function is also useful for some purposes.