### PR TITLE
fix `render is not a function` error when setting value prop

### DIFF
--- a/packages/@react-editor-js/client/src/client-editor-core.ts
+++ b/packages/@react-editor-js/client/src/client-editor-core.ts
@@ -39,6 +39,7 @@ export class ClientEditorCore implements EditorCore {
   }
 
   public async render(data: OutputData) {
+    await this._editorJS.isReady
     await this._editorJS.render(data)
   }
 }


### PR DESCRIPTION
## PR Type

- [x] Bug Fix
- [ ] Feature Request

## Description

Fixes #200 
<!-- Describe your changes -->
<!-- If you have resolved an open issue, please link the issue -->
