### PR TITLE
module property must point to ESM file

### DIFF
--- a/packages/react-editor-js/package.json
+++ b/packages/react-editor-js/package.json
@@ -3,7 +3,6 @@
   "version": "2.1.0",
   "description": "The unofficial editor-js component for React",
   "main": "./dist/react-editor-js.cjs.js",
-  "module": "./dist/react-editor-js.js",
   "types": "./dist/react-editor-js/src/index.d.ts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## PR Type

- [x] Bug Fix
- [ ] Feature Request

## Description

The module property in package.json must point to an ESM (ECMAScript Module) file. 

As a result, this library encounters issues during Vite production builds. Specifically, Vite misinterprets CJS (CommonJS) files as ESM, causing problems with handling the require function.

```
# The app does not start with the following error

react-editor-js.js:3 Uncaught ReferenceError: require is not defined
    at createReactEditorJS (react-editor-js.js:3:27)
```

<img width="506" alt="スクリーンショット 2023-09-29 13 07 56" src="https://github.com/Jungwoo-An/react-editor-js/assets/10986861/32a85874-9cfa-46aa-bb38-c1784cdbba3d">


