### PR TITLE
Update client-editor-core.ts

### DIFF
--- a/packages/@react-editor-js/client/src/client-editor-core.ts
+++ b/packages/@react-editor-js/client/src/client-editor-core.ts
@@ -39,6 +39,7 @@ export class ClientEditorCore implements EditorCore {
   }
 
   public async render(data: OutputData) {
+    await this._editorJS.isReady
     await this._editorJS.render(data)
   }
 }


### PR DESCRIPTION
Fix issue with _editorJs core client not having render method available yet when re-rendering wrapper.

## PR Type

- [x] Bug Fix
- [ ] Feature Request

## Description

Under some circumstances I receive an error that _editorJS does have a render method. I debugged and found that render is being called before the isReady promise has resolved to true. Adding the check provides safety around what seems to be a race condition.
